### PR TITLE
fix google cloud issue

### DIFF
--- a/package/urls.txt
+++ b/package/urls.txt
@@ -10,7 +10,7 @@ https://charts.kubesphere.io/test/mongodb-0.3.0.tgz
 https://charts.kubesphere.io/test/postgresql-0.4.0.tgz
 https://charts.kubesphere.io/test/rabbitmq-0.3.0.tgz
 https://charts.kubesphere.io/test/redis-0.3.2.tgz
-https://kubernetes-charts.storage.googleapis.com/memcached-3.2.3.tgz
-https://kubernetes-charts.storage.googleapis.com/mysql-1.6.6.tgz
+https://charts.helm.sh/stable/packages/memcached-3.2.3.tgz
+https://charts.helm.sh/stable/packages/mysql-1.6.6.tgz
 https://charts.kubesphere.io/test/apisix-0.1.5.tgz
 https://charts.kubesphere.io/test/porter-0.2.0.tgz


### PR DESCRIPTION
Signed-off-by: Hongliang Wang <hongliangwang@yunify.com>

Google Cloud removed the anonymous access to the helm charts. Changing to charts.helm.sh instead.